### PR TITLE
only check for subs directly in package, not parent

### DIFF
--- a/lib/Test/Exports.pm
+++ b/lib/Test/Exports.pm
@@ -183,8 +183,9 @@ sub cant_ok {
     my @nok;
 
     for (@_) {
-        my $can = $PKG->can($_);
-        $can and push @nok, $_;
+        no strict 'refs';
+        exists &{$PKG . '::' . $_}
+            and push @nok, $_;
     }
 
     my $ok = $tb->ok(!@nok, $msg);

--- a/t/exports.t
+++ b/t/exports.t
@@ -114,4 +114,11 @@ check_test
 DIAG
     "cant_ok with multiple subs";
 
+sub UNIVERSAL::from_parent { 1 }
+
+check_test
+    sub { cant_ok qw/from_parent/, "from parent" },
+    { ok => 1, name => "from parent" },
+    "cant_ok ignores parents";
+
 done_testing;


### PR DESCRIPTION
Since this module is meant for testing exported subs, it should be checking for subs directly in the test namespace and should ignore subs in the parent namespace.

This will cause it to ignore subs in the UNIVERSAL namespace, such as UNIVERSAL::import, which may exist if UNIVERSAL.pm is loaded, or on newer perl versions.